### PR TITLE
Fixed WireFitQlearn's memory leak issue

### DIFF
--- a/include/WireFitQLearn.h
+++ b/include/WireFitQLearn.h
@@ -83,6 +83,8 @@ public:
   /** Stores this model in a stream. */
   void store(std::ofstream *output);
 
+  ~WireFitQLearn();
+
 protected:
   // Feeds the state into the network, parses to the output of the network into wire form, and outputs these wires
   std::vector<Wire> getWires(State state);

--- a/src/WireFitQLearn.cpp
+++ b/src/WireFitQLearn.cpp
@@ -51,6 +51,11 @@ WireFitQLearn::WireFitQLearn(std::ifstream *input) {
 
 }
 
+WireFitQLearn::~WireFitQLearn() {
+    delete modelNet;
+    delete network;
+}
+
 Action WireFitQLearn::chooseBestAction(State currentState) {
   std::vector<double> action = bestAction(currentState);
   lastAction = action;
@@ -105,6 +110,7 @@ void WireFitQLearn::applyReinforcementToLastAction(double reward, State newState
 }
 
 void WireFitQLearn::reset() {
+  delete network;
   network = new net::NeuralNet(modelNet);
   network->randomizeWeights();
   std::cout << "number: " << network->numberOfHiddenNeurons() << "\n";


### PR DESCRIPTION
I found some memory leak issues in WireFitQLearn using Valgrind.
`modelNet` and `network` are created in the constructor but not freed in the destructor. 
Also `WireFitQLearn::reset` allocates memory for `network` but does not free the previously allocated `network`.